### PR TITLE
lx2160a: change some repos on the manifest

### DIFF
--- a/lx2160a.xml
+++ b/lx2160a.xml
@@ -2,7 +2,7 @@
 	<remote name="github" fetch="https://github.com/"/>
 	<remote name="kernel.org" fetch="https://git.kernel.org/pub/scm/linux/kernel/git"/>
 	<remote name="tf.org" fetch="https://git.trustedfirmware.org/TF-A"/>
-	<remote name="linaro-ilias" fetch="https://git.linaro.org/people/ilias.apalodimas"/>
+	<remote name="sughosh" fetch="https://git.linaro.org/people/sughosh.ganu"/>
 	<remote name="qoriq" fetch="https://source.codeaurora.org/external/qoriq/qoriq-components"/>
 
 	<default revision="refs/heads/master" remote="github" sync-j="4"/>
@@ -12,11 +12,11 @@
 	</project>
 
 	<!-- OP-TEE -->
-	<project path="optee_os"	remote="github" name="apalos/optee_os" revision="stmm_pr"/>
+	<project path="optee_os"	remote="github" name="OP-TEE/optee_os" revision="master"/>
 
 	<!-- EDK2 for StandaloneMM -->
-	<project name="edk2"		remote="linaro-ilias" revision="stmm_ffa" sync-s="true"/>
-	<project name="edk2-platforms"	remote="linaro-ilias" revision="stmm_rpmb_ffa"/>
+	<project name="edk2"		remote="sughosh" revision="ffa_svc_optional_on_upstream" sync-s="true"/>
+	<project name="edk2-platforms"	remote="sughosh" revision="ffa_svc_optional_on_upstream"/>
 
 	<project path="trusted-firmware-a" remote="github" name="glikely/trusted-firmware-a" revision="lx2160a"/>
 	<project path="u-boot" remote="github" name="glikely/u-boot" revision="lx2160a"/>


### PR DESCRIPTION
Work on lx2160 EDK2 side is currently on upstream review. Switch
branches to the ones we use for upstreaming.

The OP-TEE patches have already been upstream, so switch to upstream
OP-TEE as well

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>